### PR TITLE
Add explicit file upload permissions

### DIFF
--- a/forthebirds/settings.py
+++ b/forthebirds/settings.py
@@ -129,7 +129,7 @@ LOGIN_REDIRECT_URL = '/'
 # Miscellany
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_URLS_REGEX = r'^/radio/program-count$'
-FILE_UPLOAD_PERMISSIONS = 0o644
+FILE_UPLOAD_PERMISSIONS = 0644
 
 MARKDOWN_PROMPT = (
     'Use Markdown syntax for italics, bullets, etc. See '

--- a/forthebirds/settings.py
+++ b/forthebirds/settings.py
@@ -129,6 +129,7 @@ LOGIN_REDIRECT_URL = '/'
 # Miscellany
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_URLS_REGEX = r'^/radio/program-count$'
+FILE_UPLOAD_PERMISSIONS = 0o644
 
 MARKDOWN_PROMPT = (
     'Use Markdown syntax for italics, bullets, etc. See '


### PR DESCRIPTION
Looking at the Django docs, it appears that the version of Django that `forthebirds` uses [does not have a default value for the setting `FILE_UPLOAD_PERMISSIONS`](https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-FILE_UPLOAD_PERMISSIONS). This PR sets the value explicitly to `644` (user read+write, group read, others read).

I'm still not sure what triggered upload issues in the app in production; it's possible that a Django version bump, or a restart somehow caused this to change.